### PR TITLE
docs: fix simple typo, reverteed -> reverted

### DIFF
--- a/redis-5.0/src/redis-cli.c
+++ b/redis-5.0/src/redis-cli.c
@@ -1865,7 +1865,7 @@ static int evalMode(int argc, char **argv) {
         argv2[2] = sdscatprintf(sdsempty(),"%d",keys);
 
         /* Call it */
-        int eval_ldb = config.eval_ldb; /* Save it, may be reverteed. */
+        int eval_ldb = config.eval_ldb; /* Save it, may be reverted. */
         retval = issueCommand(argc+3-got_comma, argv2);
         if (eval_ldb) {
             if (!config.eval_ldb) {


### PR DESCRIPTION
There is a small typo in redis-5.0/src/redis-cli.c.

Should read `reverted` rather than `reverteed`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md